### PR TITLE
fixed config file for bi_generate_dataset

### DIFF
--- a/R/bi_generate_dataset.R
+++ b/R/bi_generate_dataset.R
@@ -12,19 +12,27 @@
 #' @return generated data set
 #' @export
 bi_generate_dataset <- function(endtime, noutputs, ...){
-  if (missing(endtime)){
+  full_config <- !is.null(list(...)[['config']])
+
+  if (missing(endtime) & full_config==F){
     stop("please specify the final time index!")
   }
 
-  global_options <- list()
-  if (missing(noutputs)) {
+  if (missing(noutputs) & full_config==F) {
     #noutputs missing, default to endtime
     noutputs <- endtime
-  } 
-  global_options[["end-time"]] <- endtime
-  global_options[["noutputs"]] <- endtime
-  global_options[["target"]] <- "joint"
-  global_options[["nsamples"]] <- 1
+  }
+
+  global_options <- list()
+
+  if (full_config == F){
+    global_options[["end-time"]] <- endtime
+    global_options[["noutputs"]] <- endtime
+    global_options[["target"]] <- "joint"
+    global_options[["nsamples"]] <- 1
+  } else if(is.null(list(...)[['working_folder']])){
+    stop("Cannot use a config file without specifying working_folder.")
+  }
 
   bi_object <- libbi$new(client = "sample", global_options = global_options,
                          run = TRUE, ...)

--- a/R/libbi.R
+++ b/R/libbi.R
@@ -160,7 +160,7 @@ libbi <- setRefClass("libbi",
           {
               global_options[[option]] <<- dot_options[[option]]
           }
-
+          
           .self$run(from_init = TRUE, run = run, ...)
         },
         run = function(add_options, output_file_name, stdoutput_file_name, init, input, obs, time_dim, from_init = FALSE, run = TRUE, ...){
@@ -277,6 +277,7 @@ libbi <- setRefClass("libbi",
                           sep = "\n"))
             command <<- paste(c(cdcommand, paste(launchcommand, stdoutput_redir_name)), collapse = ";")
                                         #           command_dryparse <<- paste(c(cdcommand, paste(launchcommand, "--dry-parse")), collapse = ";")
+           
             ret <- system(command)
             if (ret > 0) {
               if (!verbose) {


### PR DESCRIPTION
Previously, including a config file was broken in `bi_generate_dataset`. The variable `endtime` dominated any parameters in the config file.

Now if one supplies a config file the function recognizes this and does not set the `global_options`, but it is assumed that the config file contains the necessary variables. It might be nice to set this up so that `endtime` is also in the config file, but not necessary.

I also made changes so that if one does provide a config file, the function checks if `working_folder` is also supplied, as if not this caused a problem with the temporary directory.  